### PR TITLE
[patch] fix security vulerabiolities

### DIFF
--- a/ibm-cos-java-sdk-core/pom.xml
+++ b/ibm-cos-java-sdk-core/pom.xml
@@ -44,7 +44,7 @@
       <version>${httpcomponents.httpclient.version}</version>
     </dependency>
     <dependency>
-      <groupId>software.amazon.ion</groupId>
+      <groupId>com.amazon.ion</groupId>
       <artifactId>ion-java</artifactId>
       <version>${ion.java.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <jackson.databind.version>2.15.3</jackson.databind.version>
       <jackson.cbor.version>2.15.3</jackson.cbor.version>
       <asynchttp.version>4.1.5</asynchttp.version>
-      <ion.java.version>1.5.1</ion.java.version>
+      <ion.java.version>1.11.1</ion.java.version>
       <junit.version>4.13.2</junit.version>
       <easymock.version>3.6</easymock.version>
       <commons.logging.version>1.2</commons.logging.version>


### PR DESCRIPTION
- Have updated `software.amazon.ion` group id as deprecated in favor of com.amazon.ion. https://amazon-ion.github.io/ion-docs/news/2020/01/15/software.amazon.ion-deprecated.html
- Updated the release of com.amazon.ion to latest